### PR TITLE
Add `--open` and `--close`.

### DIFF
--- a/tests/humidity-test.toit
+++ b/tests/humidity-test.toit
@@ -18,8 +18,13 @@ class HumidityProvider extends providers.HumidityProvider:
     return 42.0
 
 class HumiditySensor implements providers.HumiditySensor:
+  is-closed/bool := false
+
   humidity-read -> float:
     return 499.0
+
+  close -> none:
+    is-closed = true
 
 main:
   provider1 := HumidityProvider
@@ -29,12 +34,19 @@ main:
   client.close
   provider1.uninstall
 
+  sensor := HumiditySensor
   provider2 := providers.HumidityProvider NAME
-      --sensor=HumiditySensor
+      --open=:: sensor
+      --close=:: it.close
       --major=MAJOR
       --minor=MINOR
   provider2.install
   client = sensors.HumidityService
+  client2 := sensors.HumidityService
   expect-equals 499.0 client.read
   client.close
+  expect-not sensor.is-closed
+  expect-equals 499.0 client2.read
+  client2.close
+  expect sensor.is-closed
   provider2.uninstall

--- a/tests/temperature-test.toit
+++ b/tests/temperature-test.toit
@@ -18,8 +18,14 @@ class TemperatureProvider extends providers.TemperatureProvider:
     return 42.0
 
 class TemperatureSensor implements providers.TemperatureSensor:
+  is-closed/bool := false
+
   temperature-read -> float:
     return 499.0
+
+  close -> none:
+    is-closed = true
+
 
 main:
   provider1 := TemperatureProvider
@@ -29,12 +35,19 @@ main:
   client.close
   provider1.uninstall
 
+  sensor := TemperatureSensor
   provider2 := providers.TemperatureProvider NAME
-      --sensor=TemperatureSensor
+      --open=:: sensor
+      --close=:: it.close
       --major=MAJOR
       --minor=MINOR
   provider2.install
   client = sensors.TemperatureService
+  client2 := sensors.TemperatureService
   expect-equals 499.0 client.read
   client.close
+  expect-not sensor.is-closed
+  expect-equals 499.0 client2.read
+  client2.close
+  expect sensor.is-closed
   provider2.uninstall


### PR DESCRIPTION
We don't want to allocate the drivers as soon as we expose the service.